### PR TITLE
Added configurable region owner/member checker for chest loots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.codisimus.plugins</groupId>
     <artifactId>phatloots</artifactId>
     <packaging>jar</packaging>
-    <version>5.5.6</version>
+    <version>5.5.7</version>
     <name>PhatLoots</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -258,6 +258,12 @@ MinimumTierNotification: 100
 SetChestsAsUnlockable: true
 
 
+##Cancel chest open if it is inside a region with specified owner or member type.
+CancelOpenIfRegionHasPlayerOwner: true
+CancelOpenIfRegionHasGroupOwner: true
+CancelOpenIfRegionHasPlayerMember: true
+CancelOpenIfRegionHasGroupMember: true
+
 ##Set this to true if you want to use decimals for your money
 ##This would turn a range of 100-1275 to 1.00-12.75
 DivideMoneyAmountBy100: false

--- a/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
@@ -6,6 +6,11 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
@@ -113,6 +118,15 @@ public class PhatLootsAPI {
         LinkedList<PhatLoot> phatLoots = PhatLoots.getPhatLoots(block, player);
         if (phatLoots.isEmpty()) {
             return false;
+        }
+
+        World wgWorld = BukkitAdapter.adapt(block.getLocation().getWorld());
+        ApplicableRegionSet applicableRegionSet = WorldGuard.getInstance().getPlatform().getRegionContainer().get(wgWorld).getApplicableRegions(BukkitAdapter.asBlockVector(block.getLocation()));
+        for (ProtectedRegion protectedRegion : applicableRegionSet.getRegions()) {
+            if (protectedRegion.getOwners().size() > 0 || protectedRegion.getMembers().getPlayers().size() > 0) {
+                //player.sendMessage("Loot cancelled because owned by player");
+                return false;
+            }
         }
 
         PhatLootChest plChest = PhatLootChest.getChest(block);

--- a/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
@@ -1,5 +1,6 @@
 package com.codisimus.plugins.phatloots;
 
+import com.codisimus.plugins.phatloots.hook.PluginHookManager;
 import com.codisimus.plugins.phatloots.loot.LootBundle;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -120,26 +121,9 @@ public class PhatLootsAPI {
             return false;
         }
 
-        World wgWorld = BukkitAdapter.adapt(block.getLocation().getWorld());
-        ApplicableRegionSet applicableRegionSet = WorldGuard.getInstance().getPlatform().getRegionContainer().get(wgWorld).getApplicableRegions(BukkitAdapter.asBlockVector(block.getLocation()));
-
-        if (PhatLootsConfig.checkIfRegionHasOwnerOrMember) {
-            for (ProtectedRegion protectedRegion : applicableRegionSet.getRegions()) {
-                if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().getPlayerDomain().size() > 0)) {
-                    return false;
-                }
-                if (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().getPlayerDomain().size() > 0) {
-                    return false;
-                }
-                if (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroupDomain().size() > 0) {
-                    return false;
-                }
-                if (PhatLootsConfig.cancelIfRegionHasGroupMember && protectedRegion.getMembers().getGroupDomain().size() > 0) {
-                    return false;
-                }
-            }
+        if (!PhatLoots.plugin.getPluginHookManager().getWorldGuardManager().isRegionLootableIfOwnerOrMembers(block)) {
+            return false;
         }
-
         PhatLootChest plChest = PhatLootChest.getChest(block);
 
         //Roll for Loot of each linked PhatLoot

--- a/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
@@ -128,7 +128,7 @@ public class PhatLootsAPI {
                 if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().size() > 0)) {
                     return false;
                 }
-                if (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().getPlayers().size() > 0) {
+                if (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().size() > 0) {
                     return false;
                 }
                 if (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroups().size() > 0) {

--- a/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
@@ -122,10 +122,16 @@ public class PhatLootsAPI {
 
         World wgWorld = BukkitAdapter.adapt(block.getLocation().getWorld());
         ApplicableRegionSet applicableRegionSet = WorldGuard.getInstance().getPlatform().getRegionContainer().get(wgWorld).getApplicableRegions(BukkitAdapter.asBlockVector(block.getLocation()));
-        for (ProtectedRegion protectedRegion : applicableRegionSet.getRegions()) {
-            if (protectedRegion.getOwners().size() > 0 || protectedRegion.getMembers().getPlayers().size() > 0) {
-                //player.sendMessage("Loot cancelled because owned by player");
-                return false;
+
+        if (PhatLootsConfig.checkIfRegionHasOwnerOrMember) {
+            for (ProtectedRegion protectedRegion : applicableRegionSet.getRegions()) {
+                if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().size() > 0) ||
+                        (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().getPlayers().size() > 0) ||
+                        (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroups().size() > 0) ||
+                        (PhatLootsConfig.cancelIfRegionHasGroupMember && protectedRegion.getMembers().getGroups().size() > 0)) {
+                    //player.sendMessage("Loot cancelled because owned by player");
+                    return false;
+                }
             }
         }
 

--- a/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
@@ -125,16 +125,16 @@ public class PhatLootsAPI {
 
         if (PhatLootsConfig.checkIfRegionHasOwnerOrMember) {
             for (ProtectedRegion protectedRegion : applicableRegionSet.getRegions()) {
-                if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().size() > 0)) {
+                if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().getPlayerDomain().size() > 0)) {
                     return false;
                 }
-                if (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().size() > 0) {
+                if (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().getPlayerDomain().size() > 0) {
                     return false;
                 }
-                if (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroups().size() > 0) {
+                if (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroupDomain().size() > 0) {
                     return false;
                 }
-                if (PhatLootsConfig.cancelIfRegionHasGroupMember && protectedRegion.getMembers().getGroups().size() > 0) {
+                if (PhatLootsConfig.cancelIfRegionHasGroupMember && protectedRegion.getMembers().getGroupDomain().size() > 0) {
                     return false;
                 }
             }

--- a/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
@@ -125,11 +125,16 @@ public class PhatLootsAPI {
 
         if (PhatLootsConfig.checkIfRegionHasOwnerOrMember) {
             for (ProtectedRegion protectedRegion : applicableRegionSet.getRegions()) {
-                if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().size() > 0) ||
-                        (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().getPlayers().size() > 0) ||
-                        (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroups().size() > 0) ||
-                        (PhatLootsConfig.cancelIfRegionHasGroupMember && protectedRegion.getMembers().getGroups().size() > 0)) {
-                    //player.sendMessage("Loot cancelled because owned by player");
+                if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().size() > 0)) {
+                    return false;
+                }
+                if (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().getPlayers().size() > 0) {
+                    return false;
+                }
+                if (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroups().size() > 0) {
+                    return false;
+                }
+                if (PhatLootsConfig.cancelIfRegionHasGroupMember && protectedRegion.getMembers().getGroups().size() > 0) {
                     return false;
                 }
             }

--- a/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsAPI.java
@@ -1,19 +1,13 @@
 package com.codisimus.plugins.phatloots;
 
-import com.codisimus.plugins.phatloots.hook.PluginHookManager;
 import com.codisimus.plugins.phatloots.loot.LootBundle;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.world.World;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
 
 /**
  * API for the PhatLoots plugin

--- a/src/com/codisimus/plugins/phatloots/PhatLootsConfig.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsConfig.java
@@ -96,8 +96,7 @@ public class PhatLootsConfig {
         cancelIfRegionHasPlayerMember = config.getBoolean("CancelOpenIfRegionHasPlayerMember", true);
         cancelIfRegionHasGroupOwner = config.getBoolean("CancelOpenIfRegionHasGroupOwner", true);
         cancelIfRegionHasGroupMember = config.getBoolean("CancelOpenIfRegionHasGroupMember", true);
-        checkIfRegionHasOwnerOrMember = (cancelIfRegionHasPlayerOwner && cancelIfRegionHasPlayerMember && cancelIfRegionHasGroupOwner && cancelIfRegionHasGroupMember);
-
+        checkIfRegionHasOwnerOrMember = (cancelIfRegionHasPlayerOwner || cancelIfRegionHasPlayerMember || cancelIfRegionHasGroupOwner || cancelIfRegionHasGroupMember);
         ConfigurationSection section = config.getConfigurationSection("AutoLink");
         if (section != null) {
             for (String world : section.getKeys(false)) {

--- a/src/com/codisimus/plugins/phatloots/PhatLootsConfig.java
+++ b/src/com/codisimus/plugins/phatloots/PhatLootsConfig.java
@@ -63,6 +63,12 @@ public class PhatLootsConfig {
     public static boolean replaceBlockLoot;
     public static boolean blockLootEnchantBonus;
 
+    public static boolean cancelIfRegionHasPlayerOwner;
+    public static boolean cancelIfRegionHasPlayerMember;
+    public static boolean cancelIfRegionHasGroupOwner;
+    public static boolean cancelIfRegionHasGroupMember;
+    public static boolean checkIfRegionHasOwnerOrMember;
+
     public static String tierPrefix;
 
     public static void load() {
@@ -85,6 +91,13 @@ public class PhatLootsConfig {
                 PhatLoots.types.put(mat, null);
             }
         }
+
+        cancelIfRegionHasPlayerOwner = config.getBoolean("CancelOpenIfRegionHasPlayerOwner", true);
+        cancelIfRegionHasPlayerMember = config.getBoolean("CancelOpenIfRegionHasPlayerMember", true);
+        cancelIfRegionHasGroupOwner = config.getBoolean("CancelOpenIfRegionHasGroupOwner", true);
+        cancelIfRegionHasGroupMember = config.getBoolean("CancelOpenIfRegionHasGroupMember", true);
+        checkIfRegionHasOwnerOrMember = (cancelIfRegionHasPlayerOwner && cancelIfRegionHasPlayerMember && cancelIfRegionHasGroupOwner && cancelIfRegionHasGroupMember);
+
         ConfigurationSection section = config.getConfigurationSection("AutoLink");
         if (section != null) {
             for (String world : section.getKeys(false)) {

--- a/src/com/codisimus/plugins/phatloots/hook/PluginHookManager.java
+++ b/src/com/codisimus/plugins/phatloots/hook/PluginHookManager.java
@@ -2,6 +2,7 @@ package com.codisimus.plugins.phatloots.hook;
 
 import com.codisimus.plugins.phatloots.PhatLoots;
 import com.codisimus.plugins.phatloots.hook.placeholder.PlaceholderManager;
+import com.codisimus.plugins.phatloots.hook.worldguard.WorldGuardManager;
 
 /**
  * Manager for managing certain plugin hooks
@@ -11,12 +12,18 @@ import com.codisimus.plugins.phatloots.hook.placeholder.PlaceholderManager;
 public class PluginHookManager {
 
     private PlaceholderManager placeholderManager;
+    private WorldGuardManager worldGuardManager;
 
     public PluginHookManager(PhatLoots plugin) {
         placeholderManager = new PlaceholderManager(plugin);
+        worldGuardManager = new WorldGuardManager(plugin);
     }
 
     public PlaceholderManager getPlaceholderManager() {
         return placeholderManager;
+    }
+
+    public WorldGuardManager getWorldGuardManager() {
+        return worldGuardManager;
     }
 }

--- a/src/com/codisimus/plugins/phatloots/hook/worldguard/WorldGuardManager.java
+++ b/src/com/codisimus/plugins/phatloots/hook/worldguard/WorldGuardManager.java
@@ -16,7 +16,7 @@ public class WorldGuardManager {
 
     public WorldGuardManager(PhatLoots plugin) {
         PluginManager pluginManager = plugin.getServer().getPluginManager();
-        if (pluginManager.getPlugin("Worldguard") != null) {
+        if (pluginManager.getPlugin("WorldGuard") != null) {
             worldGuardPlugin = WorldGuard.getInstance();
         }
     }

--- a/src/com/codisimus/plugins/phatloots/hook/worldguard/WorldGuardManager.java
+++ b/src/com/codisimus/plugins/phatloots/hook/worldguard/WorldGuardManager.java
@@ -1,0 +1,50 @@
+package com.codisimus.plugins.phatloots.hook.worldguard;
+
+import com.codisimus.plugins.phatloots.PhatLoots;
+import com.codisimus.plugins.phatloots.PhatLootsConfig;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.block.Block;
+import org.bukkit.plugin.PluginManager;
+
+public class WorldGuardManager {
+
+    private WorldGuard worldGuardPlugin;
+
+    public WorldGuardManager(PhatLoots plugin) {
+        PluginManager pluginManager = plugin.getServer().getPluginManager();
+        if (pluginManager.getPlugin("Worldguard") != null) {
+            worldGuardPlugin = WorldGuard.getInstance();
+        }
+    }
+
+    public WorldGuard getWorldGuardPlugin() {
+        return worldGuardPlugin;
+    }
+
+    public boolean isRegionLootableIfOwnerOrMembers(Block block) {
+        if (worldGuardPlugin != null && PhatLootsConfig.checkIfRegionHasOwnerOrMember) {
+            World wgWorld = BukkitAdapter.adapt(block.getLocation().getWorld());
+            ApplicableRegionSet applicableRegionSet = worldGuardPlugin.getPlatform().getRegionContainer().get(wgWorld).getApplicableRegions(BukkitAdapter.asBlockVector(block.getLocation()));
+
+            for (ProtectedRegion protectedRegion : applicableRegionSet.getRegions()) {
+                if ((PhatLootsConfig.cancelIfRegionHasPlayerOwner && protectedRegion.getOwners().getPlayerDomain().size() > 0)) {
+                    return false;
+                }
+                if (PhatLootsConfig.cancelIfRegionHasPlayerMember && protectedRegion.getMembers().getPlayerDomain().size() > 0) {
+                    return false;
+                }
+                if (PhatLootsConfig.cancelIfRegionHasGroupOwner && protectedRegion.getOwners().getGroupDomain().size() > 0) {
+                    return false;
+                }
+                if (PhatLootsConfig.cancelIfRegionHasGroupMember && protectedRegion.getMembers().getGroupDomain().size() > 0) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/com/codisimus/plugins/phatloots/listeners/BlockLootListener.java
+++ b/src/com/codisimus/plugins/phatloots/listeners/BlockLootListener.java
@@ -1,6 +1,7 @@
 package com.codisimus.plugins.phatloots.listeners;
 
 import org.bukkit.GameMode;
+import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -22,11 +23,12 @@ public class BlockLootListener implements Listener {
     @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
+        Block block = event.getBlock();
         if (player.getGameMode() == GameMode.CREATIVE)
             return; // don't drop blocks if player is in creative mode
 
         // Used namespaced name here just to prevent possible compatibility issues
-        PhatLoot phatLoot = PhatLoots.getPhatLoot("minecraft-" + event.getBlock().getType().name().toLowerCase());
+        PhatLoot phatLoot = PhatLoots.getPhatLoot("minecraft-" + block.getType().name().toLowerCase());
         if (phatLoot == null)
             return;
 
@@ -38,7 +40,7 @@ public class BlockLootListener implements Listener {
         LootBundle bundle = phatLoot.rollForLoot(enchantBonus);
         event.setExpToDrop(bundle.getExp());
         event.setDropItems(false);
-        bundle.getItemList().forEach(item -> player.getWorld().dropItemNaturally(event.getBlock().getLocation(), item));
+        bundle.getItemList().forEach(item -> player.getWorld().dropItemNaturally(block.getLocation(), item));
         bundle.getCommandList().forEach(command -> command.execute(player));
     }
 }

--- a/src/com/codisimus/plugins/phatloots/listeners/PhatLootsListener.java
+++ b/src/com/codisimus/plugins/phatloots/listeners/PhatLootsListener.java
@@ -1,7 +1,13 @@
 package com.codisimus.plugins.phatloots.listeners;
 
 import com.codisimus.plugins.phatloots.*;
+import com.codisimus.plugins.phatloots.regions.WorldGuardRegionHook;
 import com.codisimus.plugins.phatloots.util.PhatLootsUtil;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.HumanEntity;
@@ -31,7 +37,6 @@ public class PhatLootsListener implements Listener {
         if (!event.hasBlock() || event.getHand() != EquipmentSlot.HAND) {
             return;
         }
-
         boolean autoSpill = false;
         switch (event.getAction()) {
         case RIGHT_CLICK_BLOCK:


### PR DESCRIPTION
Togglable options in config.yml all true by default:
> `CancelOpenIfRegionHasPlayerOwner` -> Cancel loot chest open if chest in a region with at least one player owner
> `CancelOpenIfRegionHasGroupOwner` -> Cancel loot chest open if chest in a region with at least one player member
> `CancelOpenIfRegionHasPlayerMember` -> Cancel loot chest open if chest in a region with at least one group owner
> `CancelOpenIfRegionHasGroupMember` -> Cancel loot chest open if chest in a region with at least one group member
    
All cancel set back the default interactions (interacting with a crating table linked to a loot table but with the cancel here will work like a standard crating table) 