### PR TITLE
Fix error on entity creation or deletion in regions

### DIFF
--- a/src/com/codisimus/plugins/phatloots/regions/WorldGuardRegionHook.java
+++ b/src/com/codisimus/plugins/phatloots/regions/WorldGuardRegionHook.java
@@ -4,10 +4,9 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.world.World;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -31,7 +30,7 @@ public class WorldGuardRegionHook implements RegionHook {
             return regionNames;
         World world = BukkitAdapter.adapt(bukkitWorld);
         ApplicableRegionSet applicableRegionSet = WorldGuard.getInstance().getPlatform().getRegionContainer().get(world).getApplicableRegions(BukkitAdapter.asBlockVector(loc));
-        Set<ProtectedRegion> regionSet = applicableRegionSet.getRegions();
+        Set<ProtectedRegion> regionSet = new HashSet<>(applicableRegionSet.getRegions());
 
         //Eliminate all parent Regions
         for (ProtectedRegion protectedRegion : applicableRegionSet) {


### PR DESCRIPTION
- As far as I understand the problem is that a set has been edited before, although iterating through it. The whole thing is an invalid step. I now create a copy of the set and iterate through it. The code works and no more errors are thrown.
- Have also removed unused imports

closes #49